### PR TITLE
Get the currently configured item_size_max

### DIFF
--- a/memcached-tool-ng
+++ b/memcached-tool-ng
@@ -248,8 +248,19 @@ elsif ( $mode eq "display" ) {
     }
 
 
+    print $sock "stats settings\r\n";
+    while (<$sock>) {
+        last if /^END/;
+        chomp;
+        if (/^STAT\s+(\S*)\s+(.*)/) {
+            $items{$1} = $2;
+        }
+    }
+
     # The default slab stats
     my $defaultStats = { age => 0, total_pages => 0, chunk_size => 0, mem_requested => 0, evicted => 0, evicted_time => 0, outofmemory => 0 };
+
+    my $item_size_max = $items{item_size_max}; # normally 1024*1024 but can be larger if you've set a different -I value for memcached
 
     # Get the memory totals
     my $totMemory = 0;
@@ -259,7 +270,7 @@ elsif ( $mode eq "display" ) {
 	foreach my $p ( keys %{$defaultStats} ) {
 		$it->{$p} = $defaultStats->{$p} if ! defined $it->{$p};
 	}
-        $totMemory += $it->{total_pages}*1024*1024;
+        $totMemory += $it->{total_pages}*$item_size_max;
         $totReqMem += $it->{mem_requested};
     }
 
@@ -277,7 +288,7 @@ elsif ( $mode eq "display" ) {
             sprintf("%.1fK", $it->{chunk_size} / 1024.0);
         my $full = $it->{free_chunks_end} == 0 ? "yes" : " no";
 
-        my $usedMem = $it->{total_pages}*1024*1024;
+        my $usedMem = $it->{total_pages}*$item_size_max;
         my $effic = ($it->{mem_requested}*100)/$usedMem;
         my $ineffic = (100-$effic);
         my $totMemPct = ($usedMem * 100) / $totMemory;
@@ -287,7 +298,7 @@ elsif ( $mode eq "display" ) {
 
         printf("$colorCode %3d %10s %9ds %7d %9d %10s %12s %10.2f %% %20d %11d %12d\n",
                $n, $size, $it->{age}, $it->{total_pages} || 0,
-               $it->{number} || 0, hrMem($it->{total_pages}*1024*1024), hrMem($it->{mem_requested}), $effic, $it->{evicted},
+               $it->{number} || 0, hrMem($it->{total_pages}*$item_size_max), hrMem($it->{mem_requested}), $effic, $it->{evicted},
                $it->{evicted_time}, $it->{outofmemory});
     }
 


### PR DESCRIPTION
And use this rather than the default, hardcoded 1024*1024 value, to calculate efficiency

- useful when you've configured memcached with a -I value that isn't 1m