### PR TITLE
Use the `hrMem` function

### DIFF
--- a/memcached-tool-ng
+++ b/memcached-tool-ng
@@ -283,9 +283,7 @@ elsif ( $mode eq "display" ) {
 		$it->{$p} = $defaultStats->{$p} if ! defined $it->{$p};
 	}
         next if (0 == $it->{total_pages});
-        my $size = $it->{chunk_size} < 1024 ?
-            "$it->{chunk_size}B" :
-            sprintf("%.1fK", $it->{chunk_size} / 1024.0);
+        my $size = hrMem($it->{chunk_size});
         my $full = $it->{free_chunks_end} == 0 ? "yes" : " no";
 
         my $usedMem = $it->{total_pages}*$item_size_max;


### PR DESCRIPTION
to format the `Item_Size` column display so that item sizes are shown with bytes, KB, MB, etc.

Useful if you've set a `-I` of greater than `1m` (memcached default).

Before this PR, the display would only have bytes or K in the `Item_Size` column:

```
 #  Item_Size    Max_age   Pages     Count   Used Mem     To Store   Efficiency              Evicted  Evict_Time          OOM
   1       304B     10032s      37    264733  296.00 MB     41.10 MB      13.88 %               154154           0            0
   2       368B     10013s       3      6234   24.00 MB      1.96 MB       8.16 %                 1834           0            0
   3       440B     10031s       2      1445   16.00 MB    550.82 KB       3.36 %                 6832           0            0
   4       528B      9995s       3      2153   24.00 MB   1011.06 KB       4.11 %                    0           0            0
   5       632B     10010s       6      1929   48.00 MB      1.08 MB       2.25 %                  426           0            0
   6       752B     10028s       3      1777   24.00 MB      1.18 MB       4.90 %               134934           0            0
   7       896B     10011s       4      6837   32.00 MB      5.47 MB      17.09 %             26405675           0            0
   8       1.0K     55311s      12     62323   96.00 MB     54.49 MB      56.76 %               763790           0            0
   9       1.2K     10022s      27      7062  216.00 MB      7.96 MB       3.69 %                11305           0            0
  10       1.5K     10022s      40      6197  320.00 MB      8.32 MB       2.60 %                14591           0            0
...
  40     279.2K      9745s      10        54   80.00 MB     14.03 MB      17.54 %                12708           0            0
  41     332.2K      9594s      12        40   96.00 MB     11.73 MB      12.22 %                 2389           0            0
  42     395.4K      9998s       8        34   64.00 MB     11.78 MB      18.40 %                 7982           0            0
  43     470.5K      9152s       9        59   72.00 MB     24.48 MB      34.00 %                 1244           0            0
  44     559.9K      9491s      10        13   80.00 MB      6.33 MB       7.91 %                  289           0            0
  45     666.2K      9231s      14        58  112.00 MB     35.38 MB      31.59 %                   33           0            0
  46     792.8K      9117s       7        17   56.00 MB     11.83 MB      21.12 %                  672           0            0
  47     943.5K      9152s      20        21  160.00 MB     17.26 MB      10.79 %                    0           0            0
  48    1122.7K      8899s      21         3  168.00 MB      3.20 MB       1.90 %                    3           0            0
  49    1336.0K      8799s       8         4   64.00 MB      4.64 MB       7.24 %                  358           0            0
  50    1589.9K      8775s       5         2   40.00 MB      2.79 MB       6.98 %                  219           0            0
...
  58    6393.6K      8827s      19         2  152.00 MB     12.11 MB       7.96 %                    0           0            0
  59    8192.0K      8606s      43         2  344.00 MB     14.04 MB       4.08 %                  177           0            0
```

Now that column will show bytes, KB or MB:

```
#  Item_Size    Max_age   Pages     Count   Used Mem     To Store   Efficiency              Evicted  Evict_Time          OOM
   1      304 b     11154s      37    266092  296.00 MB     41.29 MB      13.95 %               154154           0            0
   2      368 b     11135s       3      6253   24.00 MB      1.96 MB       8.19 %                 1834           0            0
   3      440 b     11153s       2      1458   16.00 MB    555.68 KB       3.39 %                 6832           0            0
   4      528 b     11117s       3      2163   24.00 MB   1015.94 KB       4.13 %                    0           0            0
   5      632 b     11132s       6      1947   48.00 MB      1.09 MB       2.27 %                  426           0            0
   6      752 b     11150s       3      1854   24.00 MB      1.23 MB       5.11 %               134934           0            0
   7      896 b     11133s       4      6921   32.00 MB      5.53 MB      17.29 %             26405675           0            0
   8    1.05 KB     56430s      12     62161   96.00 MB     54.35 MB      56.62 %               763790           0            0
   9    1.25 KB     11144s      27      7207  216.00 MB      8.13 MB       3.76 %                11305           0            0
  10    1.49 KB     11144s      40      6289  320.00 MB      8.44 MB       2.64 %                14591           0            0
...
  41  332.23 KB     10554s      12        42   96.00 MB     12.34 MB      12.85 %                 2389           0            0
  42  395.35 KB     11120s       8        35   64.00 MB     12.15 MB      18.99 %                 7982           0            0
  43  470.47 KB     10274s       9        60   72.00 MB     24.92 MB      34.61 %                 1244           0            0
  44  559.86 KB     10613s      10        14   80.00 MB      6.86 MB       8.57 %                  289           0            0
  45  666.23 KB     10353s      14        58  112.00 MB     35.38 MB      31.59 %                   33           0            0
  46  792.82 KB     10239s       7        18   56.00 MB     12.58 MB      22.47 %                  672           0            0
  47  943.46 KB     10274s      20        21  160.00 MB     17.26 MB      10.79 %                    0           0            0
  48    1.10 MB     10021s      21         6  168.00 MB      6.32 MB       3.76 %                    3           0            0
  49    1.30 MB      9921s       8         4   64.00 MB      4.64 MB       7.24 %                  358           0            0
  50    1.55 MB      9897s       5         2   40.00 MB      2.79 MB       6.98 %                  219           0            0
...
  58    6.24 MB      9949s      19         2  152.00 MB     12.11 MB       7.96 %                    0           0            0
  59    8.00 MB      9728s      43         2  344.00 MB     14.04 MB       4.08 %                  177           0            0
```